### PR TITLE
Add customizable pair generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,9 @@ result_matrix = worker.run(backend='gpu',
 
 - **Before run tutorial_config.py, batch_size parameter must be modified to fit your gpu memory size**
 - **You can set parameters and run FastTENET via a YAML file**
-- **The config file must have values set for all required parameters**
+- **The config file must have values set for all required parameters**. \
+You can also set `PAIR_MODE` to choose how node pairs are generated, and
+provide any required file paths via `PAIR_DATA`.
 
 #### Usage
 ```angular2html
@@ -212,6 +214,15 @@ python tutorial_config.py --config [config file path]
 #### Example
 ```angular2html
 python tutorial_config.py --config ../configs/config_tuck_sub.yml
+```
+
+Example YAML snippet for pair generation:
+```yaml
+PAIR_MODE: tenet_plus
+PAIR_DATA:
+  peaks: TE_peak_list.txt
+  tf_list: tf_list.txt
+  gene_chr: gene_chr.txt
 ```
 
 #### Output

--- a/configs/config_skin.yml
+++ b/configs/config_skin.yml
@@ -24,3 +24,5 @@ KP: 0.5
 # the SMOOTHING_OPT parameter is optional and must be dictionary type (ex. {'method': 'exp'})
 # 'mov', 'savgol', 'exp', 'loess' method parameters are available.
 SMOOTHING_OPT: None
+PAIR_MODE: default
+PAIR_DATA: null

--- a/configs/config_tuck_sub.yml
+++ b/configs/config_tuck_sub.yml
@@ -24,3 +24,5 @@ KP: 0.5
 # the SMOOTHING_OPT parameter is optional and must be dictionary type (ex. {'method': 'exp'})
 # 'mov', 'savgol', 'exp', 'loess' method parameters are available.
 SMOOTHING_OPT: None
+PAIR_MODE: default
+PAIR_DATA: null

--- a/fasttenet/fasttenet.py
+++ b/fasttenet/fasttenet.py
@@ -12,6 +12,17 @@ import mate
 
 from fasttenet.utils import load_exp_data, load_time_data
 from fasttenet.utils import get_device_list, align_data
+from fasttenet.utils import (
+    create_TENET_Plus_pairs,
+    create_tf_peak_pairs,
+    create_tf_gene_pairs,
+    create_tf_gene_peak_pairs,
+    create_cis_peaksource_pairs,
+    create_peak_peak_pairs,
+    load_sif_connections,
+    load_gene_chr_mapping,
+    load_file_to_list,
+)
 
 class FastTENET(object):
     def __init__(self,
@@ -105,8 +116,51 @@ class FastTENET(object):
             binning_opt: dict = None,
             smoothing_opt: dict = None,
             dt=1,
+            pair_mode: str = 'default',
+            pair_data: dict = None,
             config=None
             ):
+        """Run FastTENET and generate a result matrix.
+
+        Parameters
+        ----------
+        backend : str, optional
+            Backend framework to use. Defaults to ``"cpu"``.
+        device_ids : list[int] or int, optional
+            Device ids to run on.
+        procs_per_device : int, optional
+            Number of worker processes per device.
+        batch_size : int, optional
+            Mini-batch size.
+        num_kernels : int, optional
+            Number of kernels for MATE.
+        binning_method : str, optional
+            Discretization method.
+        kp : float, optional
+            Kernel parameter.
+        binning_opt : dict, optional
+            Options for discretization.
+        smoothing_opt : dict, optional
+            Options for smoothing.
+        dt : int, optional
+            Time step for TE calculation.
+        pair_mode : str, optional
+            Strategy used to form node pairs. ``"default"`` reproduces the
+            original FastTENET behaviour. Other modes require additional data
+            specified via ``pair_data``.
+        pair_data : dict, optional
+            Extra data used when ``pair_mode`` is not ``"default"``. File paths
+            may be provided and will be loaded automatically.
+        config : dict, optional
+            Configuration dictionary. ``PAIR_MODE`` and ``PAIR_DATA`` keys will
+            override the corresponding arguments if present.
+        """
+
+        if config:
+            if 'PAIR_MODE' in config:
+                pair_mode = config['PAIR_MODE']
+            if 'PAIR_DATA' in config and pair_data is None:
+                pair_data = config['PAIR_DATA']
 
         if not backend:
             if config:
@@ -160,19 +214,109 @@ class FastTENET(object):
         else:
             arr = align_data(data=self._exp_data, trj=self._trajectory, branch=self._branch)
 
+        gene_names_dict = {name: idx for idx, name in enumerate(self._node_name)}
         pairs = []
-        if self._tf is not None:
-            _, inds_source, _ = np.intersect1d(self._node_name, self._tf, return_indices=True)
 
-            for ix_t in range(len(self._node_name)):
-                for ix_s in inds_source:
-                    if ix_t==ix_s:
-                        continue
-                    pairs.append((ix_t, ix_s))
+        if pair_mode == 'default':
+            if self._tf is not None:
+                _, inds_source, _ = np.intersect1d(self._node_name, self._tf, return_indices=True)
+                for ix_t in range(len(self._node_name)):
+                    for ix_s in inds_source:
+                        if ix_t == ix_s:
+                            continue
+                        pairs.append((ix_t, ix_s))
+            else:
+                pairs = list(permutations(range(len(arr)), 2))
+
+        elif pair_mode == 'tenet_plus':
+            if not pair_data:
+                raise ValueError('pair_data is required for tenet_plus mode')
+            peaks = pair_data.get('peaks')
+            tf_list = pair_data.get('tf_list', [])
+            gene_chr = pair_data.get('gene_chr')
+
+            if isinstance(peaks, str):
+                peaks = load_file_to_list(peaks)
+            if isinstance(tf_list, str):
+                tf_list = load_file_to_list(tf_list)
+            if isinstance(gene_chr, str):
+                gene_chr = load_gene_chr_mapping(gene_chr)
+
+            genes_per_chr = {}
+            for gene, chr_ in gene_chr.items():
+                if gene in gene_names_dict:
+                    genes_per_chr.setdefault(chr_, []).append(gene)
+
+            only_peak_dict = {g: i for g, i in gene_names_dict.items() if g in peaks}
+            pairs = create_TENET_Plus_pairs(peaks, genes_per_chr, gene_names_dict, tf_list)
+
+        elif pair_mode == 'tf_gene':
+            if not pair_data:
+                raise ValueError('pair_data is required for tf_gene mode')
+            tf_list = pair_data.get('tf_list', [])
+            if isinstance(tf_list, str):
+                tf_list = load_file_to_list(tf_list)
+            only_gene_dict = {g: i for g, i in gene_names_dict.items() if g not in pair_data.get('peaks', [])}
+            pairs = create_tf_gene_pairs(gene_names_dict, only_gene_dict, tf_list)
+
+        elif pair_mode == 'tf_peak':
+            if not pair_data:
+                raise ValueError('pair_data is required for tf_peak mode')
+            tf_list = pair_data.get('tf_list', [])
+            peaks = pair_data.get('peaks', [])
+            if isinstance(tf_list, str):
+                tf_list = load_file_to_list(tf_list)
+            if isinstance(peaks, str):
+                peaks = load_file_to_list(peaks)
+            only_peak_dict = {g: i for g, i in gene_names_dict.items() if g in peaks}
+            pairs = create_tf_peak_pairs(gene_names_dict, only_peak_dict, tf_list)
+
+        elif pair_mode == 'tf_gene_peak':
+            if not pair_data:
+                raise ValueError('pair_data is required for tf_gene_peak mode')
+            tf_list = pair_data.get('tf_list', [])
+            if isinstance(tf_list, str):
+                tf_list = load_file_to_list(tf_list)
+            pairs = create_tf_gene_peak_pairs(gene_names_dict, tf_list)
+
+        elif pair_mode == 'cis_peak_gene':
+            if not pair_data:
+                raise ValueError('pair_data is required for cis_peak_gene mode')
+            peaks = pair_data.get('peaks')
+            gene_chr = pair_data.get('gene_chr')
+            if isinstance(peaks, str):
+                peaks = load_file_to_list(peaks)
+            if isinstance(gene_chr, str):
+                gene_chr = load_gene_chr_mapping(gene_chr)
+            genes_per_chr = {}
+            for gene, chr_ in gene_chr.items():
+                if gene in gene_names_dict:
+                    genes_per_chr.setdefault(chr_, []).append(gene)
+            pairs = create_cis_peaksource_pairs(peaks, genes_per_chr, gene_names_dict)
+
+        elif pair_mode == 'cis_peak_peak':
+            if not pair_data:
+                raise ValueError('pair_data is required for cis_peak_peak mode')
+            peaks = pair_data.get('peaks', [])
+            if isinstance(peaks, str):
+                peaks = load_file_to_list(peaks)
+            only_peak_dict = {g: i for g, i in gene_names_dict.items() if g in peaks}
+            pairs = create_peak_peak_pairs(peaks, only_peak_dict, max_distance=None)
+
+        elif pair_mode == 'triplet':
+            if not pair_data or 'sif_file' not in pair_data:
+                raise ValueError('pair_data with "sif_file" is required for triplet mode')
+            sif_file = pair_data['sif_file']
+            if isinstance(sif_file, str):
+                tf_gene, tf_peak, peak_gene = load_sif_connections(sif_file, gene_names_dict)
+                pairs = tf_gene + tf_peak + peak_gene
+            else:
+                raise ValueError('sif_file must be a file path')
+
         else:
-            pairs = permutations(range(len(arr)), 2)
+            raise ValueError(f'Invalid pair_mode: {pair_mode}')
 
-        pairs = np.asarray(tuple(pairs), dtype=np.int32)
+        pairs = np.asarray(list(set(pairs)), dtype=np.int32)
 
         if backend == 'lightning' or backend == 'gpu' or backend == 'cuda':
             self._mate = mate.MATELightning(arr=arr,

--- a/fasttenet/utils/__init__.py
+++ b/fasttenet/utils/__init__.py
@@ -1,2 +1,14 @@
 from fasttenet.utils.utils import get_device_list, align_data
 from fasttenet.utils.fileio import load_exp_data, load_time_data
+from fasttenet.utils.pairs import (
+    load_gene_chr_mapping,
+    load_file_to_list,
+    create_TENET_Plus_pairs,
+    create_tf_peak_pairs,
+    create_tf_gene_pairs,
+    create_tf_gene_peak_pairs,
+    create_cis_peaksource_pairs,
+    create_peak_peak_pairs,
+    load_sif_connections,
+)
+

--- a/fasttenet/utils/pairs.py
+++ b/fasttenet/utils/pairs.py
@@ -1,0 +1,179 @@
+"""Utility functions for generating node pairs."""
+
+from typing import Dict, Iterable, List, Tuple, Optional
+
+
+def load_gene_chr_mapping(filename: str) -> Dict[str, str]:
+    """Load mapping from gene name to chromosome."""
+    mapping: Dict[str, str] = {}
+    with open(filename, "r") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            chromosome, gene = line.strip().split()
+            if gene.startswith("chr"):
+                # skip lines that start with chr as gene name
+                continue
+            mapping[gene] = chromosome
+    return mapping
+
+
+def load_file_to_list(filename: str) -> List[str]:
+    """Load a file into a list, stripping trailing newlines."""
+    with open(filename, "r") as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+# Pair generation functions return 0-indexed pairs ---------------------------
+
+def create_TENET_Plus_pairs(
+    peaks: Iterable[str],
+    genes_per_chromosome: Dict[str, List[str]],
+    gene_names_dict: Dict[str, int],
+    tf_list: Iterable[str],
+) -> List[Tuple[int, int]]:
+    """Create gene–gene pairs based on TENET+ logic."""
+    gene_pairs: List[Tuple[int, int]] = []
+    for peak in peaks:
+        peak_chr = peak.split("-")[0]
+        peak_idx = gene_names_dict.get(peak)
+        if peak_idx is not None:
+            for gene in genes_per_chromosome.get(peak_chr, []):
+                if gene in gene_names_dict:
+                    gene_pairs.append((peak_idx, gene_names_dict[gene]))
+
+    tf_indices = [gene_names_dict[tf] for tf in tf_list if tf in gene_names_dict]
+    for tf_idx in tf_indices:
+        for gene, gidx in gene_names_dict.items():
+            if gidx != tf_idx:
+                gene_pairs.append((tf_idx, gidx))
+
+    return gene_pairs
+
+
+def create_tf_peak_pairs(
+    gene_names_dict: Dict[str, int],
+    only_peak_names_dict: Dict[str, int],
+    tf_list: Iterable[str],
+) -> List[Tuple[int, int]]:
+    """Create TF->peak pairs."""
+    peak_pairs: List[Tuple[int, int]] = []
+    tf_indices = [gene_names_dict[tf] for tf in tf_list if tf in gene_names_dict]
+    for tf_idx in tf_indices:
+        for peak, pidx in only_peak_names_dict.items():
+            if pidx != tf_idx:
+                peak_pairs.append((tf_idx, pidx))
+    return peak_pairs
+
+
+def create_tf_gene_pairs(
+    gene_names_dict: Dict[str, int],
+    only_gene_names_dict: Dict[str, int],
+    tf_list: Iterable[str],
+) -> List[Tuple[int, int]]:
+    """Create TF->gene pairs."""
+    gene_pairs: List[Tuple[int, int]] = []
+    tf_indices = [gene_names_dict[tf] for tf in tf_list if tf in gene_names_dict]
+    for tf_idx in tf_indices:
+        for gene, gidx in only_gene_names_dict.items():
+            if gidx != tf_idx:
+                gene_pairs.append((tf_idx, gidx))
+    return gene_pairs
+
+
+def create_tf_gene_peak_pairs(
+    gene_names_dict: Dict[str, int],
+    tf_list: Iterable[str],
+) -> List[Tuple[int, int]]:
+    """Create TF->gene and TF->peak pairs in one list."""
+    gene_pairs: List[Tuple[int, int]] = []
+    tf_indices = [gene_names_dict[tf] for tf in tf_list if tf in gene_names_dict]
+    for tf_idx in tf_indices:
+        for gene, gidx in gene_names_dict.items():
+            if gidx != tf_idx:
+                gene_pairs.append((tf_idx, gidx))
+    return gene_pairs
+
+
+def create_cis_peaksource_pairs(
+    peaks: Iterable[str],
+    genes_per_chromosome: Dict[str, List[str]],
+    gene_names_dict: Dict[str, int],
+) -> List[Tuple[int, int]]:
+    """Create cis peak->gene pairs."""
+    gene_pairs: List[Tuple[int, int]] = []
+    for peak in peaks:
+        peak_chr = peak.split("-")[0]
+        peak_idx = gene_names_dict.get(peak)
+        if peak_idx is not None:
+            for gene in genes_per_chromosome.get(peak_chr, []):
+                if gene in gene_names_dict:
+                    gene_pairs.append((peak_idx, gene_names_dict[gene]))
+    return gene_pairs
+
+
+def create_peak_peak_pairs(
+    peaks: Iterable[str],
+    only_peak_names_dict: Dict[str, int],
+    max_distance: Optional[int] = 1000000,
+) -> List[Tuple[int, int]]:
+    """Create directed cis peak->peak pairs within an optional distance limit."""
+    peak_pairs: List[Tuple[int, int]] = []
+    peaks_by_chr: Dict[str, List[Tuple[str, int, int]]] = {}
+    for peak in peaks:
+        parts = peak.split("-")
+        if len(parts) < 3:
+            continue
+        chrom, start_str, end_str = parts[0], parts[1], parts[2]
+        try:
+            start, end = int(start_str), int(end_str)
+        except ValueError:
+            continue
+        if peak in only_peak_names_dict:
+            peaks_by_chr.setdefault(chrom, []).append((peak, start, end))
+
+    for chrom, plist in peaks_by_chr.items():
+        for i in range(len(plist)):
+            p1, s1, e1 = plist[i]
+            for j in range(len(plist)):
+                if i == j:
+                    continue
+                p2, s2, e2 = plist[j]
+                if e1 < s2:
+                    dist = s2 - e1
+                elif e2 < s1:
+                    dist = s1 - e2
+                else:
+                    dist = 0
+                if max_distance is None or dist <= max_distance:
+                    idx1 = only_peak_names_dict[p1]
+                    idx2 = only_peak_names_dict[p2]
+                    peak_pairs.append((idx1, idx2))
+    return peak_pairs
+
+
+def load_sif_connections(
+    filename: str,
+    gene_names_dict: Dict[str, int],
+) -> Tuple[List[Tuple[int, int]], List[Tuple[int, int]], List[Tuple[int, int]]]:
+    """Load connections from a SIF file."""
+    tf_gene_pairs: List[Tuple[int, int]] = []
+    tf_peak_pairs: List[Tuple[int, int]] = []
+    peak_gene_pairs: List[Tuple[int, int]] = []
+
+    with open(filename, "r") as f:
+        header = f.readline()
+        for line_number, line in enumerate(f, start=2):
+            parts = line.strip().split()
+            if len(parts) < 7:
+                continue
+            TF, gene, peak, *_ = parts
+            if TF in gene_names_dict and gene in gene_names_dict:
+                tf_gene_pairs.append((gene_names_dict[TF], gene_names_dict[gene]))
+            if TF in gene_names_dict and peak in gene_names_dict:
+                tf_peak_pairs.append((gene_names_dict[TF], gene_names_dict[peak]))
+            if peak in gene_names_dict and gene in gene_names_dict:
+                peak_gene_pairs.append((gene_names_dict[peak], gene_names_dict[gene]))
+
+    return tf_gene_pairs, tf_peak_pairs, peak_gene_pairs
+


### PR DESCRIPTION
## Summary
- add new `pairs` utility module for various pair generation methods
- expose pair utilities in `fasttenet.utils`
- support `pair_mode` and `pair_data` options in `FastTENET.run`
- document pair mode and pair data in README
- add `PAIR_MODE` and `PAIR_DATA` to example configs

## Testing
- `python -m py_compile fasttenet/utils/pairs.py fasttenet/fasttenet.py fasttenet/utils/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_688c27e1dc5883239659ef90909244fb